### PR TITLE
refactor: 모달 컴포넌트의 구현 및 사용 방식 변경

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -17,25 +17,24 @@ export const Playground: Story<ModalProps> = (args) => {
     <div>
       <button onClick={toggleModal}>Toggle Modal</button>
 
-      <Modal
-        {...args}
-        isOpen={isOpen}
-        toggleModal={toggleModal}
-        actions={[
-          {
-            actionId: "cancel",
-            label: "취소하기",
-            variant: "outlined",
-          },
-          {
-            actionId: "confirm",
-            label: "확인하기",
-            variant: "solid",
-            onClick: () => console.log("확인하였습니다."),
-          },
-        ]}
-      >
-        모달 콘텐츠입니다.
+      <Modal {...args} isOpen={isOpen} toggleModal={toggleModal}>
+        <Modal.Body
+          actions={[
+            {
+              actionId: "cancel",
+              label: "취소하기",
+              variant: "outlined",
+            },
+            {
+              actionId: "confirm",
+              label: "확인하기",
+              variant: "solid",
+              onClick: () => console.log("확인하였습니다."),
+            },
+          ]}
+        >
+          <h1>모달 콘텐츠</h1>
+        </Modal.Body>
       </Modal>
     </div>
   );

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,1 +1,2 @@
 export { default } from "./Modal";
+export type { ModalAction, ModalBodyProps, ModalProps } from "./Modal";

--- a/src/features/coupons/components/CouponSelectModal/CouponSelectModal.tsx
+++ b/src/features/coupons/components/CouponSelectModal/CouponSelectModal.tsx
@@ -1,36 +1,31 @@
 "use client";
 
-import Modal from "@/components/Modal";
+import Modal, { ModalProps } from "@/components/Modal";
 import Radio from "@/components/Radio";
 import { Coupon } from "@/mockers/types";
 import { useState } from "react";
 import "react-responsive-modal/styles.css";
 import styles from "./CouponSelectModal.module.scss";
 
-export interface CouponSelectModalProps {
-  isOpen: boolean;
-  toggleModal: (nextIsOpen?: boolean) => void;
+export interface CouponSelectModalProps extends ModalProps {
   coupons: Coupon[];
   defaultSelectdCouponId?: string;
   onConfirmCoupon: (selectedCouponId: string) => void;
 }
 
 const CouponSelectModal: React.FC<CouponSelectModalProps> = (props) => {
-  if (!props.isOpen) {
-    return null;
-  }
+  const { isOpen, toggleModal, ...couponSelectModalProps } = props;
 
-  return <CouponSelectModalImpl {...props} />;
+  return (
+    <Modal isOpen={props.isOpen} toggleModal={props.toggleModal}>
+      <CouponSelectModalBody {...couponSelectModalProps} />
+    </Modal>
+  );
 };
 
-const CouponSelectModalImpl: React.FC<
-  Omit<CouponSelectModalProps, "isOpen">
-> = ({
-  toggleModal,
-  coupons = [],
-  defaultSelectdCouponId,
-  onConfirmCoupon,
-}) => {
+const CouponSelectModalBody: React.FC<
+  Omit<CouponSelectModalProps, "isOpen" | "toggleModal">
+> = ({ coupons = [], defaultSelectdCouponId, onConfirmCoupon }) => {
   const [selectedCouponId, updateSelectedCouponId] = useState(
     defaultSelectdCouponId ?? undefined,
   );
@@ -42,9 +37,7 @@ const CouponSelectModalImpl: React.FC<
   };
 
   return (
-    <Modal
-      isOpen
-      toggleModal={toggleModal}
+    <Modal.Body
       actions={[
         {
           actionId: "cancel",
@@ -72,7 +65,7 @@ const CouponSelectModalImpl: React.FC<
           />
         ))}
       </Radio.Group>
-    </Modal>
+    </Modal.Body>
   );
 };
 


### PR DESCRIPTION
- 모달 컴포넌트의 Body 콘텐츠가 Modal Lifecycle에 맞추어 상태를 관리할 수 있도록 구조를 변경하였습니다.
  - Modal은 모달 요소의 생애주기를 관리합니다.
  - Modal.Body는 모달 내부의 상태, 콘텐츠를 관리합니다.